### PR TITLE
add global stack navigation event management

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,60 @@ useEffect((): any => {
 </NavigationContainer>;
 ```
 
+### Global Stack Navigator Events
+
+To listen to the Stack navigator events from anywhere, you need to import `navigationListenerProps` and spread it as props. It is currently limited to a single stack navigator.
+```jsx
+import { isReadyRef, navigationRef, navigationListenerProps } from "react-navigation-helpers";
+
+useEffect((): any => {
+  return () => (isReadyRef.current = false);
+}, []);
+
+<NavigationContainer
+  ref={navigationRef}
+  onReady={() => {
+    isReadyRef.current = true;
+  }}
+>
+  <Stack.Navigator {...navigationListenerProps}>
+      {/* Rest of your code */}
+  </Stack.Navigator>
+</NavigationContainer>;
+```
+
+you can then listen to [stack navigation events](https://reactnavigation.org/docs/stack-navigator#events) anywhere in your app.
+
+Example in a component:
+```jsx
+import React, {useEffect} from "react"
+import {addNavigationListener} from "react-navigation-helpers"
+// or as a whole
+import * as NavigationService from "react-navigation-helpers";
+
+const MyComponent = () => {
+    
+    useEffect(() => {
+        return addNavigationListener("transitionEnd", () => {
+            // transition ended
+        })
+    })
+
+    // or like this
+    useEffect(() => {
+        return NavigationService.addNavigationListener("transitionEnd", () => {
+            // transition ended
+        })
+    })
+    
+    return (
+        <Text>Hello world!</Text>
+    )
+}
+```
+
+
+
 ## NavigationService Usage
 
 ### Navigate Example

--- a/lib/NavigationService.ts
+++ b/lib/NavigationService.ts
@@ -9,18 +9,18 @@ interface RefObject<T> {
 }
 
 export type NavigationEvent =
-  | "transitionStart"
-  | "transitionEnd"
-  | "gestureStart"
-  | "gestureEnd"
-  | "gestureCancel"
-  | string;
+    | "transitionStart"
+    | "transitionEnd"
+    | "gestureStart"
+    | "gestureEnd"
+    | "gestureCancel"
+    | string;
 
 const listeners: Record<string, ((...args: any[]) => void)[]> = {};
 
 const removeNavigationListener = (
-  event: string,
-  callback: (...args: any[]) => void,
+    event: string,
+    callback: (...args: any[]) => void,
 ) => {
   if (listeners[event]) {
     listeners[event] = listeners[event].filter((cb) => cb !== callback);
@@ -29,13 +29,13 @@ const removeNavigationListener = (
 
 const executeNavigationListeners = (eventName: string, ...args: any) => {
   if (listeners[eventName]) {
-    listeners[eventName].forEach((fn) => fn(args));
+    listeners[eventName].forEach((fn) => fn(...args));
   }
 };
 
 export const addNavigationListener = (
-  event: NavigationEvent,
-  callback: any,
+    event: NavigationEvent,
+    callback: any,
 ): (() => void) => {
   listeners[event] = listeners[event] || [];
   listeners[event].push(callback);
@@ -48,15 +48,15 @@ export const navigationRef = createNavigationContainerRef<any>();
 
 export const navigationListenerProps = {
   onTransitionEnd: (props, ...args) =>
-    executeNavigationListeners("transitionEnd", args),
+      executeNavigationListeners("transitionEnd", ...args),
   onTransitionStart: (props, ...args) =>
-    executeNavigationListeners("transitionStart", args),
+      executeNavigationListeners("transitionStart", ...args),
   onGestureStart: (props, ...args) =>
-    executeNavigationListeners("gestureStart", args),
+      executeNavigationListeners("gestureStart", ...args),
   onGestureEnd: (props, ...args) =>
-    executeNavigationListeners("gestureEnd", args),
+      executeNavigationListeners("gestureEnd", ...args),
   onGestureCancel: (props, ...args) =>
-    executeNavigationListeners("gestureCancel", args),
+      executeNavigationListeners("gestureCancel", ...args),
 };
 
 export const navigate = (routeName: string, params?: any) => {

--- a/lib/NavigationService.ts
+++ b/lib/NavigationService.ts
@@ -8,8 +8,56 @@ interface RefObject<T> {
   current: T | null;
 }
 
+export type NavigationEvent =
+  | "transitionStart"
+  | "transitionEnd"
+  | "gestureStart"
+  | "gestureEnd"
+  | "gestureCancel"
+  | string;
+
+const listeners: Record<string, ((...args: any[]) => void)[]> = {};
+
+const removeNavigationListener = (
+  event: string,
+  callback: (...args: any[]) => void,
+) => {
+  if (listeners[event]) {
+    listeners[event] = listeners[event].filter((cb) => cb !== callback);
+  }
+};
+
+const executeNavigationListeners = (eventName: string, ...args: any) => {
+  if (listeners[eventName]) {
+    listeners[eventName].forEach((fn) => fn(args));
+  }
+};
+
+export const addNavigationListener = (
+  event: NavigationEvent,
+  callback: any,
+): (() => void) => {
+  listeners[event] = listeners[event] || [];
+  listeners[event].push(callback);
+
+  return () => removeNavigationListener(event, callback);
+};
+
 export const isReadyRef: RefObject<boolean> = React.createRef<boolean>();
 export const navigationRef = createNavigationContainerRef<any>();
+
+export const navigationListenerProps = {
+  onTransitionEnd: (props, ...args) =>
+    executeNavigationListeners("transitionEnd", args),
+  onTransitionStart: (props, ...args) =>
+    executeNavigationListeners("transitionStart", args),
+  onGestureStart: (props, ...args) =>
+    executeNavigationListeners("gestureStart", args),
+  onGestureEnd: (props, ...args) =>
+    executeNavigationListeners("gestureEnd", args),
+  onGestureCancel: (props, ...args) =>
+    executeNavigationListeners("gestureCancel", args),
+};
 
 export const navigate = (routeName: string, params?: any) => {
   if (isReadyRef.current && navigationRef && navigationRef.current) {

--- a/v6-example/App.tsx
+++ b/v6-example/App.tsx
@@ -3,7 +3,7 @@ import { Text, View, SafeAreaView } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { isReadyRef, navigationRef } from "react-navigation-helpers";
+import { isReadyRef, navigationRef, navigationListenerProps } from "react-navigation-helpers";
 /**
  * ? Local Imports
  */
@@ -33,7 +33,7 @@ const App = () => {
           isReadyRef.current = true;
         }}
       >
-        {/* <Stack.Navigator>
+        {/* <Stack.Navigator {...navigationListenerProps}>
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="Settings" component={SettingsScreen} />
         </Stack.Navigator> */}

--- a/v6-example/src/screens/HomeScreen.tsx
+++ b/v6-example/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect} from "react"
 import { View, Text, Button, StyleProp, ViewStyle } from "react-native";
 import * as NavigationService from "react-navigation-helpers";
 /**
@@ -13,6 +13,14 @@ interface IHomeScreenProps {
 }
 
 const HomeScreen: React.FC<IHomeScreenProps> = ({ style }) => {
+
+    useEffect(() => {
+        return NavigationService.addNavigationListener("transitionEnd", () => {
+            // stack navigation transition ended
+            // https://reactnavigation.org/docs/stack-navigator#events
+        })
+    }, [])
+
   return (
     <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
       <Text>Home Screen</Text>


### PR DESCRIPTION
This adds global stack navigator event management (soft limited to a single stack navigator).

[linked issue](https://github.com/WrathChaos/react-navigation-helpers/issues/349)